### PR TITLE
symlink module and target dependencies to global instances in the kubos-sdk container

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -10,3 +10,5 @@ RUN cd /kubos-sdk/dist && ./repo sync
 RUN mv /kubos-sdk/dist/yotta_modules /usr/lib/yotta_modules
 
 RUN mv /kubos-sdk/dist/yotta_targets /usr/lib/yotta_targets
+
+RUN python /kubos-sdk/dist/symlink.py

--- a/dist/symlink.py
+++ b/dist/symlink.py
@@ -1,9 +1,32 @@
 #!/usr/bin/env python
 
-import os
-import subprocess
+# Kubos SDK
+# Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# This scrit sets up the symlinks for the global yotta modules and targets when 
+
+# This is the kubos-sdk "target" script that is executed inside the kubostech/kubos-sdk 
+# docker container image. The project directory on the host is mounted
+# into a container instance, then this script executed commands such as: build, init and target
+# against the project directory.
+
+import argparse
+import os
+
+from yotta import link, link_target
+
+# This script sets up the symlinks for the global yotta modules and targets when 
 # building the kubos-sdk docker container
 
 def main():
@@ -13,26 +36,31 @@ def main():
     root_target_path = os.path.join('/', 'usr', 'lib', 'yotta_targets')
     
     for subdir in os.listdir(root_module_path):
-        module_dirs.append(os.path.join(root_module_path, subdir))
+        module_dir = os.path.join(root_module_path, subdir)
+        # to only set up half of the symlink, the cwd must be the module directory
+        # the second half of the symlink is currently created before building the project
+        os.chdir(module_dir)   
+        print 'Linking: %s' % module_dir
+        _link()
 
     for subdir in os.listdir(root_target_path):
-        target_dirs.append(os.path.join(root_target_path, subdir))
-
-    link('link', module_dirs)
-    link('link-target', target_dirs)
-
-
-def link(link_cmd, dir_list):
-    for directory in dir_list:
-        cmd('yotta', link_cmd, cwd=directory)
+        target_dir = os.path.join(root_target_path, subdir)
+        os.chdir(target_dir)   
+        print 'Linking Target: %s' % target_dir
+        _link_target()
 
 
-def cmd(*args, **kwargs):
-    try:
-        subprocess.check_call(args, **kwargs)
-    except subprocess.CalledProcessError, e:
-        print >>sys.stderr, 'Error executing command, giving up'
-        sys.exit(1)
+def _link():
+    link_args = argparse.Namespace(module_or_path=None,
+                                   config=None,
+                                   target=None)
+    link.execCommand(link_args, None)
+
+def _link_target():
+    link_target_args = argparse.Namespace(target_or_path=None,
+                                   config=None,
+                                   target=None)
+    link_target.execCommand(link_target_args, None)
 
 
 if __name__ == '__main__':

--- a/dist/symlink.py
+++ b/dist/symlink.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+
+# This scrit sets up the symlinks for the global yotta modules and targets when 
+# building the kubos-sdk docker container
+
+def main():
+    module_dirs = []
+    target_dirs=[]
+    root_module_path = os.path.join('/', 'usr', 'lib', 'yotta_modules')
+    root_target_path = os.path.join('/', 'usr', 'lib', 'yotta_targets')
+    
+    for subdir in os.listdir(root_module_path):
+        module_dirs.append(os.path.join(root_module_path, subdir))
+
+    for subdir in os.listdir(root_target_path):
+        target_dirs.append(os.path.join(root_target_path, subdir))
+
+    link('link', module_dirs)
+    link('link-target', target_dirs)
+
+
+def link(link_cmd, dir_list):
+    for directory in dir_list:
+        cmd('yotta', link_cmd, cwd=directory)
+
+
+def cmd(*args, **kwargs):
+    try:
+        subprocess.check_call(args, **kwargs)
+    except subprocess.CalledProcessError, e:
+        print >>sys.stderr, 'Error executing command, giving up'
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/kubos-sdk.py
+++ b/kubos-sdk.py
@@ -129,11 +129,11 @@ def set_target(new_target):
     target_list = os.listdir(global_target_pth)
     available_target_list = []
     
-    for targ in target_list:
-        if targ.startswith('target-'):
-            available_target_list.append(targ[7:])
-        else:
-            available_target_list.append(targ)
+    for subdir in target_list:
+        target_json = os.path.join(global_target_pth, subdir, 'target.json')
+        with open(target_json, 'r') as json_file:
+            data = json.load(json_file)
+            available_target_list.append(data['name'])
     
     if new_target in available_target_list:
         globalconf.set('plain', False)
@@ -147,7 +147,7 @@ def set_target(new_target):
         target.execCommand(link_target_args, '')
     else:
         if new_target != '':
-            print >>sys.stderr, 'Error: Requested target %s not available. Available targets are:\n', new_target
+            print >>sys.stderr, 'Error: Requested target %s not available. Available targets are:\n' % new_target
         else:
             print >>sys.stderr, 'Available targets are:\n'
         for _target in available_target_list:
@@ -169,9 +169,11 @@ def get_current_target():
 def local_link_deps():
     root_module_path = os.path.join('/','usr', 'lib', 'yotta_modules')
     for subdir in os.listdir(root_module_path):
-        if subdir == 'libcsp':
-            subdir = 'csp'
-        link_args = argparse.Namespace(module_or_path=subdir,
+        module_json = os.path.join(root_module_path, subdir, 'module.json')
+        with open(module_json, 'r') as json_file:
+            data = json.load(json_file)
+            module_name = data['name']
+        link_args = argparse.Namespace(module_or_path=module_name,
                                        config=None,
                                        target=get_current_target())
         link.execCommand(link_args, None)

--- a/kubos-sdk.py
+++ b/kubos-sdk.py
@@ -139,7 +139,7 @@ def set_target(new_target):
         globalconf.set('plain', False)
         link_target_args = argparse.Namespace(target_or_path=new_target, 
                                               config=None,
-                                              target=get_current_target() or new_target,
+                                              target=new_target,
                                               set_target=new_target,
                                               save_global=False,
                                               no_install=False)
@@ -167,7 +167,7 @@ def get_current_target():
 
 
 def local_link_deps():
-    root_module_path = os.path.join('/','usr', 'lib', 'yotta_modules')
+    root_module_path = os.path.join('/','usr', 'local', 'lib', 'yotta_modules')
     for subdir in os.listdir(root_module_path):
         module_json = os.path.join(root_module_path, subdir, 'module.json')
         with open(module_json, 'r') as json_file:


### PR DESCRIPTION
This update symlinks the global modules on the build command to avoid downloading. 

It also links to the local targets and simplifies the target selection process: 
`kubos target msp430f5529-gcc` 
instead of
`kubos target msp430f5529-gcc@openkosmosorg/target...`

If a user requests a target that is unavailable it now prints a list of locally available targets too.

This would fix #11  and fix #7 