### PR TITLE
Pass unknown commands to yotta

### DIFF
--- a/kubos
+++ b/kubos
@@ -25,6 +25,17 @@ import time
 from docker import Client
 import docker
 
+# Override the argparse error handler that deals with undefined subcommands
+# to allow these commands to be passed through to the container. The container
+# handles passing commands to yotta as well as subcommands unknown to yotta.
+
+def pass_through_check_value(self, action, value):
+    if action.choices is not None and value not in action.choices:
+        pass_through(value)
+        sys.exit()
+
+argparse.ArgumentParser._check_value = pass_through_check_value
+
 container_name = 'kubostech/kubos-sdk'
 yotta_meta_file = '.yotta.json'
 module_file_name = 'module.json'

--- a/kubos
+++ b/kubos
@@ -25,17 +25,6 @@ import time
 from docker import Client
 import docker
 
-# Override the argparse error handler that deals with undefined subcommands
-# to allow these commands to be passed through to the container. The container
-# handles passing commands to yotta as well as subcommands unknown to yotta.
-
-def pass_through_check_value(self, action, value):
-    if action.choices is not None and value not in action.choices:
-        pass_through(value)
-        sys.exit()
-
-argparse.ArgumentParser._check_value = pass_through_check_value
-
 container_name = 'kubostech/kubos-sdk'
 yotta_meta_file = '.yotta.json'
 module_file_name = 'module.json'
@@ -238,5 +227,18 @@ def get_current_target():
     else:
         return None
 
+
+# Override the argparse error handler that deals with undefined subcommands
+# to allow these commands to be passed through to the container. The container
+# handles passing commands to yotta as well as subcommands unknown to yotta.
+
+def pass_through_check_value(self, action, value):
+    if action.choices is not None and value not in action.choices:
+        pass_through(value)
+        sys.exit()
+
+argparse.ArgumentParser._check_value = pass_through_check_value
+
 if __name__ == '__main__':
     main()
+

--- a/kubos
+++ b/kubos
@@ -30,6 +30,7 @@ yotta_meta_file = '.yotta.json'
 module_file_name = 'module.json'
 
 def main():
+    argparse.ArgumentParser._check_value = pass_through_check_value
     parser = argparse.ArgumentParser('kubos')
     subparser = parser.add_subparsers(dest='command', help='Available kubos commands')
 
@@ -237,7 +238,6 @@ def pass_through_check_value(self, action, value):
         pass_through(value)
         sys.exit()
 
-argparse.ArgumentParser._check_value = pass_through_check_value
 
 if __name__ == '__main__':
     main()

--- a/kubos-sdk.py
+++ b/kubos-sdk.py
@@ -32,6 +32,20 @@ import xml.etree.ElementTree as ET
 from yotta import build, init, target
 from yotta.lib import component, globalconf
 
+# Temporarily override the argparse error handler that deals with undefined subcommands
+# to allow these subcommands to be passed to yotta. Before calling yotta
+# the error handler is set back to the standard argparse handler.
+
+original_check_value = argparse.ArgumentParser._check_value
+
+def kubos_check_value(self, action, value):
+    if action.choices is not None and value not in action.choices:
+        argparse.ArgumentParser._check_value = original_check_value
+        import yotta
+        yotta.main()
+
+argparse.ArgumentParser._check_value = kubos_check_value
+
 kubos_rt = 'kubos-rt'
 kubos_rt_branch = '~0.0.1'
 org_name = 'openkosmosorg'

--- a/kubos-sdk.py
+++ b/kubos-sdk.py
@@ -42,7 +42,10 @@ yotta_install_path = '/usr/local/bin/yotta'
 
 target_const = '_show_current_target_'
 
+original_check_value = argparse.ArgumentParser._check_value
+
 def main():    
+    argparse.ArgumentParser._check_value = kubos_check_value
     parser    = argparse.ArgumentParser('kubos-sdk')
     subparser = parser.add_subparsers(dest='command')
     
@@ -147,15 +150,11 @@ def cmd(*args, **kwargs):
 # to allow these subcommands to be passed to yotta. Before calling yotta
 # the error handler is set back to the standard argparse handler.
 
-original_check_value = argparse.ArgumentParser._check_value
-
 def kubos_check_value(self, action, value):
     if action.choices is not None and value not in action.choices:
         argparse.ArgumentParser._check_value = original_check_value
         import yotta
         yotta.main()
-
-argparse.ArgumentParser._check_value = kubos_check_value
 
 if __name__ == '__main__':
     main()

--- a/kubos-sdk.py
+++ b/kubos-sdk.py
@@ -32,20 +32,6 @@ import xml.etree.ElementTree as ET
 from yotta import build, init, target
 from yotta.lib import component, globalconf
 
-# Temporarily override the argparse error handler that deals with undefined subcommands
-# to allow these subcommands to be passed to yotta. Before calling yotta
-# the error handler is set back to the standard argparse handler.
-
-original_check_value = argparse.ArgumentParser._check_value
-
-def kubos_check_value(self, action, value):
-    if action.choices is not None and value not in action.choices:
-        argparse.ArgumentParser._check_value = original_check_value
-        import yotta
-        yotta.main()
-
-argparse.ArgumentParser._check_value = kubos_check_value
-
 kubos_rt = 'kubos-rt'
 kubos_rt_branch = '~0.0.1'
 org_name = 'openkosmosorg'
@@ -157,5 +143,20 @@ def cmd(*args, **kwargs):
         print >>sys.stderr, 'Error executing command, giving up'
         sys.exit(1)
 
+# Temporarily override the argparse error handler that deals with undefined subcommands
+# to allow these subcommands to be passed to yotta. Before calling yotta
+# the error handler is set back to the standard argparse handler.
+
+original_check_value = argparse.ArgumentParser._check_value
+
+def kubos_check_value(self, action, value):
+    if action.choices is not None and value not in action.choices:
+        argparse.ArgumentParser._check_value = original_check_value
+        import yotta
+        yotta.main()
+
+argparse.ArgumentParser._check_value = kubos_check_value
+
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
This works by:

- Completely overriding the error handler in the host script (Allows passing the command to the container)
- Temporarily overriding the same handler in the container script
 - Before the command is passed to yotta the handler is set back to its default

This wil fix #8 
