### PR TITLE
First debugging implementation for stm32f407discovery and msp430f5529-gcc targets

### DIFF
--- a/kubos/debug.py
+++ b/kubos/debug.py
@@ -33,6 +33,9 @@ load
 '''
 
 def addOptions(parser):
+    '''
+    This is a required function that's called from main when this module is imported
+    '''
     pass
 
 
@@ -42,11 +45,11 @@ def execCommand(args, following_args):
         print >>sys.stderr, 'Set a target and build your project before debugging'
         sys.exit(1)
     generate_gdb_commands(current_target)
-    if server.get_server_status() == 'stopped':
+    if server.get_server_status() == server.server_stopped:
         print 'Kubos GDB server not running...\nStarting GDB Server...'
         server.start_server()
     gdb_file_path = os.path.join(os.getcwd(), gdb_command_file)
-    if current_target.startswith('stm32'):
+    if current_target.startswith('stm32') or current_target.startswith('na'):
         command = ['arm-none-eabi-gdb', '-x', gdb_file_path]
     elif current_target.startswith('msp430'):
         command = ['msp430-gdb', '-x', gdb_file_path]
@@ -82,8 +85,4 @@ def get_host_ip():
 def get_kubos_dir():
     kubos_dir = resource_filename(__name__, '')
     return kubos_dir
-
-
-if __name__ == '__main__':
-    execCommand(None,None)
 

--- a/kubos/flash.py
+++ b/kubos/flash.py
@@ -56,7 +56,7 @@ def flash_openocd(proj_exe_path, kubos_dir):
         openocd_exe = os.path.join(kubos_dir, 'bin', 'osx', 'openocd')
         lib_path = os.path.join(kubos_dir, 'lib', 'osx')
 
-    check_env_var(lib_path)
+    project.check_env_var(lib_path)
     openocd_dir = os.path.join(kubos_dir, 'flash', 'openocd')
     flash_script_path = os.path.join(openocd_dir, 'flash.sh')
     argument = 'stm32f4_flash %s' % proj_exe_path
@@ -74,7 +74,7 @@ def flash_dfu_util(proj_exe_path, kubos_dir):
         dfu_util_exe = os.path.join(kubos_dir, 'bin', 'osx', 'dfu-util')
         lib_path = os.path.join(kubos_dir, 'lib', 'osx')
 
-    check_env_var(lib_path)
+    project.check_env_var(lib_path)
     dfu_util_dir = os.path.join(kubos_dir, 'flash', 'dfu_util')
     flash_script_path = os.path.join(dfu_util_dir, 'flash.sh')
     try:
@@ -91,7 +91,7 @@ def flash_mspdebug(proj_exe_path, kubos_dir):
         mspdebug_exe = os.path.join(kubos_dir, 'bin', 'osx', 'mspdebug')
         lib_path = os.path.join(kubos_dir, 'lib', 'osx')
 
-    check_env_var(lib_path)
+    project.check_env_var(lib_path)
     flash_script_path = os.path.join(kubos_dir, 'flash', 'mspdebug', 'flash.sh')
     argument = 'prog %s' % proj_exe_path
     try:
@@ -99,9 +99,3 @@ def flash_mspdebug(proj_exe_path, kubos_dir):
     except subprocess.CalledProcessError:
         pass
 
-def check_env_var(path):
-    ld_lib_path = 'LD_LIBRARY_PATH'
-    if not hasattr(os.environ, ld_lib_path):
-        os.environ[ld_lib_path] = path
-    else:
-        os.environ[ld_lib_path] += ':%s' % path

--- a/kubos/flash.py
+++ b/kubos/flash.py
@@ -56,7 +56,7 @@ def flash_openocd(proj_exe_path, kubos_dir):
         openocd_exe = os.path.join(kubos_dir, 'bin', 'osx', 'openocd')
         lib_path = os.path.join(kubos_dir, 'lib', 'osx')
 
-    project.check_env_var(lib_path)
+    project.add_ld_library_path(lib_path)
     openocd_dir = os.path.join(kubos_dir, 'flash', 'openocd')
     flash_script_path = os.path.join(openocd_dir, 'flash.sh')
     argument = 'stm32f4_flash %s' % proj_exe_path
@@ -74,7 +74,7 @@ def flash_dfu_util(proj_exe_path, kubos_dir):
         dfu_util_exe = os.path.join(kubos_dir, 'bin', 'osx', 'dfu-util')
         lib_path = os.path.join(kubos_dir, 'lib', 'osx')
 
-    project.check_env_var(lib_path)
+    project.add_ld_library_path(lib_path)
     dfu_util_dir = os.path.join(kubos_dir, 'flash', 'dfu_util')
     flash_script_path = os.path.join(dfu_util_dir, 'flash.sh')
     try:
@@ -91,7 +91,7 @@ def flash_mspdebug(proj_exe_path, kubos_dir):
         mspdebug_exe = os.path.join(kubos_dir, 'bin', 'osx', 'mspdebug')
         lib_path = os.path.join(kubos_dir, 'lib', 'osx')
 
-    project.check_env_var(lib_path)
+    project.add_ld_library_path(lib_path)
     flash_script_path = os.path.join(kubos_dir, 'flash', 'mspdebug', 'flash.sh')
     argument = 'prog %s' % proj_exe_path
     try:

--- a/kubos/main.py
+++ b/kubos/main.py
@@ -74,6 +74,7 @@ def main():
     add_parser('list', 'list', 'List module dependencies', help='List the dependencies of the current module, or the inherited targets of the current target')
     add_parser('remove', 'remove', 'remove a symlinked module', help='Remove a symlinked module')
     add_parser('search', 'search', 'Search for modules and targets', help='Search for published modules and targets')
+    add_parser('server', 'server', 'Kubos debug GDB server', help='Interact with the Kubos GDB server')
     add_parser('shrinkwrap', 'shrinkwrap', 'Create a yotta-shrinkwrap.json file to freeze dependency versions', help='free dependency versions')
     add_parser('target', 'target', 'Set the target device', help='Set or display the current target device')
     add_parser('test', 'test', 'Run the tests for the current module on the current target. Requires target support for cross-compiling targets', help='Run the tests for the current module or target')

--- a/kubos/server.py
+++ b/kubos/server.py
@@ -1,0 +1,129 @@
+# Kubos SDK
+# Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import psutil
+import subprocess
+import sys
+import time
+
+from options import parser
+from pkg_resources import resource_filename
+from utils import container, project, target
+
+
+def addOptions(parser):
+    parser.add_argument('action', nargs='?', help='Interact directly with the gdb server. Options: start, stop, restart or status')
+
+
+def execCommand(args, following_args):
+    if args.action == 'start':
+        start_server()
+    elif args.action == 'status':
+        print_server_status()
+    elif args.action == 'stop':
+        stop_server()
+    elif args.action =='restart':
+        restart_server()
+
+
+def start_server():
+    current_target = target.get_current_target()
+    flash_dir, lib_dir, exe_dir = get_dirs()
+    project.check_env_var(lib_dir)
+    if not current_target:
+        print >>sys.stderr, 'Set a target hardware device and build your project before debugging'
+
+    if current_target.startswith('stm32'):
+        flash_script = os.path.join(flash_dir, 'openocd', 'flash.sh')
+        util_exe = os.path.join(exe_dir, 'openocd')
+        proc = subprocess.Popen(['/bin/bash', flash_script, util_exe, '', lib_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    elif current_target.startswith('msp430'):
+        flash_script = os.path.join(flash_dir, 'mspdebug', 'flash.sh')
+        util_exe = os.path.join(exe_dir, 'mspdebug')
+        proc = subprocess.Popen(['/bin/bash', flash_script, util_exe, 'gdb 3333'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    #catch failed server starts
+    time.sleep(0.5)
+    status = get_server_status()
+    if status == 'stopped':
+        print >>sys.stderr, 'GDB server failed to start... Ensure your target device is connected'
+        sys.exit(1)
+    elif status == 'running':
+        print 'Server successfully Started'
+
+
+def get_server_status():
+    flash_util = get_flash_util()
+    process = get_server_process(flash_util)
+    if process:
+        return 'running'
+    else:
+        return 'stopped'
+
+
+def print_server_status():
+    print 'Kubos GDB Server status: %s' % get_server_status()
+
+
+def stop_server():
+    flash_util = get_flash_util()
+    process = get_server_process(flash_util)
+    if process:
+        process.terminate()
+        print 'Server Shut Down...'
+    else:
+        print 'Server is not running... Nothing to do'
+
+
+def restart_server():
+    stop_server()
+    start_server()
+
+
+def get_server_process(util_name):
+    full_list = psutil.process_iter()
+    for proc in full_list:
+        try:
+            if proc.name() == util_name:
+                return proc
+        except psutil.ZombieProcess:
+            pass
+    return None
+
+
+def get_flash_util():
+    current_target = target.get_current_target()
+    if not current_target:
+        print >>sys.stderr, 'No Target is currently set. Cannot start the gdb server'
+        sys.exit(1)
+    if current_target.startswith('stm32'):
+        flash_util = 'openocd'
+    elif current_target.startswith('msp430'):
+        flash_util = 'mspdebug'
+    return flash_util
+
+
+def get_dirs():
+    kubos_dir = resource_filename(__name__, '')
+    flash_dir = os.path.join(kubos_dir, 'flash')
+    if sys.platform.startswith('linux'):
+        bin_dir = os.path.join(kubos_dir, 'bin', 'linux')
+        lib_dir = os.path.join(kubos_dir, 'lib', 'linux')
+    elif sys.platform.startswith('darwin'):
+        bin_dir = os.path.join(kubos_dir, 'bin', 'osx')
+        lib_dir = os.path.join(kubos_dir, 'lib', 'osx')
+    return flash_dir, lib_dir, bin_dir
+

--- a/kubos/utils/getip.sh
+++ b/kubos/utils/getip.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+docker-machine ssh "${DOCKER_MACHINE_NAME}" 'echo ${SSH_CONNECTION%% *}'

--- a/kubos/utils/project.py
+++ b/kubos/utils/project.py
@@ -40,3 +40,12 @@ def get_local_link_file():
     path = os.path.join(this_dir, '.kubos-link.json')
     return path
 
+
+def check_env_var(path):
+    ld_lib_path = 'LD_LIBRARY_PATH'
+    if not hasattr(os.environ, ld_lib_path):
+        os.environ[ld_lib_path] = path
+    else:
+        os.environ[ld_lib_path] += ':%s' % path
+
+

--- a/kubos/utils/project.py
+++ b/kubos/utils/project.py
@@ -41,7 +41,7 @@ def get_local_link_file():
     return path
 
 
-def check_env_var(path):
+def add_ld_library_path(path):
     ld_lib_path = 'LD_LIBRARY_PATH'
     if not hasattr(os.environ, ld_lib_path):
         os.environ[ld_lib_path] = path

--- a/setup.json
+++ b/setup.json
@@ -9,6 +9,7 @@
         "yotta",
         "docker-py",
         "dockerpty",
-        "psutil"
+        "psutil",
+        "setuptools"
     ]
 }

--- a/setup.json
+++ b/setup.json
@@ -7,6 +7,8 @@
     "url": "http://github.com/openkosmosorg/kubos-sdk",
     "install_requires": [
         "yotta",
-        "docker-py"
+        "docker-py",
+        "dockerpty",
+        "psutil"
     ]
 }

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,13 @@ for ascii_key in ("name", "version"):
 
 setup_data["packages"] = find_packages()
 
-setup(data_files=[
+setup(classifiers=[
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7'
+        ],
+        data_files=[
+        ('/kubos/utils',                ['kubos/utils/getip.sh']),
         ('/kubos/flash/mspdebug', ['flash/mspdebug/flash.sh']),
         ('/kubos/flash/dfu_util', ['flash/dfu_util/flash.sh']),
         ('/kubos/flash/openocd',  ['flash/openocd/flash.sh',


### PR DESCRIPTION
This would fix #34 - with the debug implementation and fix #42 - by no longer calling the wrapper function to get the container output that was broken on Fedora 24. 