### PR TITLE
Link targets from host into container

### DIFF
--- a/kubos/link_target.py
+++ b/kubos/link_target.py
@@ -42,63 +42,68 @@ def execCommand(args, following_args):
         link_global(os.getcwd())
 
 
-def link_global(module_path):
-    module_json = os.path.join(module_path, 'module.json')
-    if os.path.isfile(module_json):
-        with open(module_json, 'r') as mod_json:
-            module_data = json.load(mod_json)
-            module_name = module_data['name']
+def link_global(target_path):
+    target_path = os.path.abspath(target_path)
+    target_json = os.path.join(target_path, 'target.json')
+    if os.path.isfile(target_json):
+        with open(target_json, 'r') as targ_json:
+            try:
+                target_data = json.load(targ_json)
+                target_name = target_data['name']
+            except ValueError:
+                print >>sys.stderr, 'Error parsing data from: %s \nAre you sure it contains Vailid JSON data?' % target_json
+                sys.exit(1)
     else:
-        print >>sys.stderr, 'Error, unable to link %s does not contain a module.json' % module_path
+        print >>sys.stderr, 'Error, unable to link %s does not contain a target.json' % module_path
         sys.exit(1)
 
     global_link_file = get_global_link_file()
     if os.path.isfile(global_link_file):
         with open(global_link_file, 'r') as meta_file:
             link_data = json.load(meta_file)
-            link_data[module_key][module_name] = module_path
+            link_data[target_key][target_name] = target_path
     else:
         link_data = {
-                        module_key : {module_name : module_path},
-                        target_key : {}
+                        target_key : {target_name : target_path},
+                        module_key : {}
                     }
 
     #write the updated changes back to the global file
     with open(global_link_file, 'w') as meta_file:
         str_link_data = json.dumps(link_data)
         meta_file.write(str_link_data)
-        print 'Successfully Linked %s: %s' % (module_name, module_path)
-    return module_name
+        print 'Successfully Linked %s: %s' % (target_name, target_path)
+    return target_name
 
 
-def link_global_to_local(module_name):
+def link_global_to_local(target_name):
     local_link_file = get_local_link_file()
     global_link_file = get_global_link_file()
 
     if os.path.isfile(global_link_file):
         with open(global_link_file, 'r') as global_file:
             global_links = json.load(global_file)
-        if module_name in global_links[module_key]:
+        if target_name in global_links[target_key]:
             if os.path.isfile(local_link_file):
                 with open(local_link_file, 'r') as link_file:
                     link_data = json.load(link_file)
             else:
                 link_data = {
-                                module_key: {},
-                                target_key: {}
+                                target_key: {},
+                                module_key: {}
                             }
-            module_path = global_links[module_key][module_name]
-            link_data[module_key][module_name] = module_path
+            target_path = global_links[target_key][target_name]
+            link_data[target_key][target_name] = target_path
 
             with open(local_link_file, 'w') as link_file:
                 links = json.dumps(link_data)
                 link_file.write(links)
         else:
-            print >>sys.stderr, 'Error module %s not linked globally' % module_name
+            print >>sys.stderr, 'Error module %s not linked globally' % target_name
             sys.exit(1)
     else:
         print >>sys.stderr, 'No modules are currently linked globally'
         sys.exit(1)
 
-    print 'Successfully Linked %s: %s Locally' % (module_name, module_path)
+    print 'Successfully Linked %s: %s Locally' % (target_name, target_path)
 

--- a/kubos/main.py
+++ b/kubos/main.py
@@ -41,7 +41,7 @@ def main():
     if os.name == 'nt':
         import logging
         logging.warning('Windows is not currently supported. Many of the features in the Kubos-sdk will most likely not work correctly or at all on computers running Windows')
-    
+
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
         description='kubos - the SDK for working with the KubOS RTOS\n'+
@@ -70,7 +70,8 @@ def main():
     add_parser('flash', 'flash', 'Flash the target device', help='Flash and start the built executable on the current target')
     add_parser('init', 'init', 'Initialize a new KubOS project', help='Create a new module')
     add_parser('licenses', 'licenses', 'Print licenses for dependencies', help='List the licenses of the current module and its dependencies')
-    add_parser('link', 'link', 'Symlink a module', help='Flash and start the built executable on the current target')
+    add_parser('link', 'link', 'Symlink a module', help='Symlink a module to be used in the build of another module')
+    add_parser('link-target', 'link_target', 'Symlink a target', help='Symlink a target into a kubos project')
     add_parser('list', 'list', 'List module dependencies', help='List the dependencies of the current module, or the inherited targets of the current target')
     add_parser('remove', 'remove', 'remove a symlinked module', help='Remove a symlinked module')
     add_parser('search', 'search', 'Search for modules and targets', help='Search for published modules and targets')

--- a/kubos/utils/project.py
+++ b/kubos/utils/project.py
@@ -18,6 +18,11 @@ import os
 
 module_file_name = 'module.json'
 
+#keys for link json data
+module_key = 'modules'
+target_key = 'targets'
+target_mount_dir = os.path.join('/', 'usr', 'lib', 'yotta_targets')
+
 def get_project_name():
     module_file_path = os.path.join(os.getcwd(), module_file_name)
     if os.path.isfile(module_file_path):


### PR DESCRIPTION
Add link-target command. Convert link files to hold both targets and modules. utils/container mounts both modules and targets. 